### PR TITLE
Complete runtime rules design

### DIFF
--- a/entity/card.go
+++ b/entity/card.go
@@ -2,12 +2,18 @@ package entity
 
 import (
 	"github.com/sunist-c/genius-invokation-simulator-backend/enum"
+	"github.com/sunist-c/genius-invokation-simulator-backend/model/context"
 	"github.com/sunist-c/genius-invokation-simulator-backend/model/kv"
 )
 
 type Card interface {
 	ID() uint
 	Type() enum.CardType
+}
+
+type FoodCard interface {
+	Card
+	ExecuteModify(ctx *context.ModifierContext)
 }
 
 // CardDeck 牌堆，记录顺序的是一个数组，正常情况下已取出的牌永远在队列的一端

--- a/entity/character.go
+++ b/entity/character.go
@@ -78,6 +78,9 @@ type Character interface {
 	// ExecuteDefence 根据DamageContext对角色进行伤害结算，不包括效果结算
 	ExecuteDefence(ctx *context.DamageContext)
 
+	// ExecuteEatFood 根据食物卡的效果执行食物结算
+	ExecuteEatFood(ctx *context.ModifierContext)
+
 	// ExecuteAttack 使用skill进行对target角色和background后台角色进行攻击
 	ExecuteAttack(skill, target uint, background []uint) (ctx *context.DamageContext)
 
@@ -272,6 +275,11 @@ func (c *character) ExecuteDirectAttackModifiers(ctx *context.DamageContext) {
 
 func (c *character) ExecuteFinalAttackModifiers(ctx *context.DamageContext) {
 	c.localFinalAttackModifiers.Execute(ctx)
+}
+
+func (c *character) ExecuteEatFood(ctx *context.ModifierContext) {
+	c.ExecuteModify(ctx)
+	c.satiety = true
 }
 
 func (c character) ID() uint {

--- a/entity/player.go
+++ b/entity/player.go
@@ -22,6 +22,8 @@ type Player interface {
 	ReRollTimes() uint
 	StaticCost() Cost
 	HoldingCost() Cost
+	SwitchNextCharacter()
+	SwitchPrevCharacter()
 	SwitchCharacter(target uint)
 	ExecuteAttack(skill, target uint, background []uint) (result *context.DamageContext)
 	ExecuteModify(ctx *context.ModifierContext)
@@ -32,6 +34,10 @@ type Player interface {
 	ExecuteElementReRoll(drop Cost)
 	ExecuteBurnCard(card uint, exchangeElement enum.ElementType)
 	ExecuteEatFood(card, targetCharacter uint)
+	ExecuteDirectAttackModifiers(ctx *context.DamageContext)
+	ExecuteFinalAttackModifiers(ctx *context.DamageContext)
+	ExecuteAfterAttackCallback()
+	ExecuteAfterDefenceCallback()
 }
 
 type player struct {
@@ -42,13 +48,13 @@ type player struct {
 	reRollTimes uint // reRollTimes 重新投掷的次数
 	staticCost  Cost // staticCost 每回合投掷阶段固定产出的骰子
 
-	holdingCost     Cost                    // holdingCost 玩家持有的骰子
-	cardDeck        CardDeck                // cardDeck 玩家的牌堆
-	holdingCards    kv.Map[uint, Card]      // holdingCards 玩家持有的卡牌
-	activeCharacter uint                    // activeCharacter 玩家当前的前台角色
-	characters      kv.Map[uint, Character] // characters 玩家出战的角色
-	summons         kv.Map[uint, Summon]    // summons 玩家在场的召唤物
-	supports        kv.Map[uint, Support]   // supports 玩家在场的支援
+	holdingCost     Cost                           // holdingCost 玩家持有的骰子
+	cardDeck        CardDeck                       // cardDeck 玩家的牌堆
+	holdingCards    kv.Map[uint, Card]             // holdingCards 玩家持有的卡牌
+	activeCharacter uint                           // activeCharacter 玩家当前的前台角色
+	characters      kv.OrderedMap[uint, Character] // characters 玩家出战的角色
+	summons         kv.OrderedMap[uint, Summon]    // summons 玩家在场的召唤物
+	supports        kv.OrderedMap[uint, Support]   // supports 玩家在场的支援
 
 	globalDirectAttackModifiers AttackModifiers  // globalDirectAttackModifiers 全局直接攻击修正
 	globalFinalAttackModifiers  AttackModifiers  // globalFinalAttackModifiers 全局最终攻击修正
@@ -118,13 +124,11 @@ func (p *player) executeCallbackModify(ctx *context.CallbackContext) {
 
 	// 执行ElementAttachment
 	attachment := ctx.AttachElementResult()
-	for target := range attachment {
+	for target, element := range attachment {
 		if p.characters.Exists(target) {
-			// todo: implement me
-			panic("implement rule.reaction")
+			p.characters.Get(target).ExecuteElementAttachment(element)
 		}
 	}
-
 }
 
 func (p *player) executeCallbackEvent(trigger enum.TriggerType) {
@@ -157,8 +161,42 @@ func (p player) HoldingCost() Cost {
 	return p.holdingCost
 }
 
+func (p *player) SwitchNextCharacter() {
+	// notice: 如果只有一人，此处不进行切换
+	index := p.characters.GetIndex(p.activeCharacter)
+	for i := index + 1; i < p.characters.Length(); i++ {
+		if character := p.characters.Get(p.characters.GetKey(i)); character.Status() != enum.CharacterStatusDefeated {
+			p.SwitchCharacter(character.ID())
+			return
+		}
+	}
+	for i := uint(0); i < index; i++ {
+		if character := p.characters.Get(p.characters.GetKey(i)); character.Status() != enum.CharacterStatusDefeated {
+			p.SwitchCharacter(character.ID())
+			return
+		}
+	}
+}
+
+func (p *player) SwitchPrevCharacter() {
+	// notice: 如果只有一人，此处不进行切换
+	index := p.characters.GetIndex(p.activeCharacter)
+	for i := index - 1; i >= 0; i-- {
+		if character := p.characters.Get(p.characters.GetKey(i)); character.Status() != enum.CharacterStatusDefeated {
+			p.SwitchCharacter(character.ID())
+			return
+		}
+	}
+	for i := p.characters.Length(); i > index; i-- {
+		if character := p.characters.Get(p.characters.GetKey(i)); character.Status() != enum.CharacterStatusDefeated {
+			p.SwitchCharacter(character.ID())
+			return
+		}
+	}
+}
+
 func (p *player) SwitchCharacter(target uint) {
-	if p.characters.Exists(target) {
+	if p.characters.Exists(target) && p.activeCharacter != target {
 		p.characters.Get(p.activeCharacter).SwitchDown()
 		p.activeCharacter = target
 		p.characters.Get(target).SwitchUp()
@@ -281,6 +319,24 @@ func (p *player) ExecuteAttack(skill, target uint, background []uint) (result *c
 	return p.characters.Get(p.activeCharacter).ExecuteAttack(skill, target, background)
 }
 
+func (p *player) ExecuteDirectAttackModifiers(ctx *context.DamageContext) {
+	p.globalDirectAttackModifiers.Execute(ctx)
+	p.characters.Get(p.activeCharacter).ExecuteDirectAttackModifiers(ctx)
+}
+
+func (p *player) ExecuteFinalAttackModifiers(ctx *context.DamageContext) {
+	p.globalFinalAttackModifiers.Execute(ctx)
+	p.characters.Get(p.activeCharacter).ExecuteFinalAttackModifiers(ctx)
+}
+
+func (p *player) ExecuteAfterAttackCallback() {
+	p.executeCallbackEvent(enum.AfterAttack)
+}
+
+func (p *player) ExecuteAfterDefenceCallback() {
+	p.executeCallbackEvent(enum.AfterDefence)
+}
+
 func (p *player) ExecuteElementPayment(basic, pay Cost) (success bool) {
 	if p.PreviewElementCost(basic).Equals(pay) {
 		ctx := context.NewCostContext()
@@ -334,9 +390,9 @@ func NewPlayer(info PlayerInfo) Player {
 		cardDeck:                    *NewCardDeck(info.Cards()),
 		holdingCards:                kv.NewSimpleMap[Card](),
 		activeCharacter:             0,
-		characters:                  kv.NewSimpleMap[Character](),
-		summons:                     kv.NewSimpleMap[Summon](),
-		supports:                    kv.NewSimpleMap[Support](),
+		characters:                  kv.NewOrderedMap[uint, Character](),
+		summons:                     kv.NewOrderedMap[uint, Summon](),
+		supports:                    kv.NewOrderedMap[uint, Support](),
 		globalDirectAttackModifiers: modifier.NewChain[context.DamageContext](),
 		globalFinalAttackModifiers:  modifier.NewChain[context.DamageContext](),
 		globalDefenceModifiers:      modifier.NewChain[context.DamageContext](),

--- a/entity/rule.go
+++ b/entity/rule.go
@@ -1,0 +1,62 @@
+package entity
+
+import (
+	"github.com/sunist-c/genius-invokation-simulator-backend/enum"
+	"github.com/sunist-c/genius-invokation-simulator-backend/model/context"
+)
+
+type ReactionCalculator interface {
+	// ReactionCalculate 计算当前角色身上附着的元素之间能否发生反应，返回反应类型和剩余元素
+	ReactionCalculate([]enum.ElementType) (reaction enum.Reaction, elementRemains []enum.ElementType)
+
+	// DamageCalculate 根据反应类型计算对应的伤害修正
+	DamageCalculate(reaction enum.Reaction, ctx *context.DamageContext)
+
+	// EffectCalculate 根据反应类型计算对应的反应效果
+	EffectCalculate(reaction enum.Reaction) (ctx *context.CallbackContext)
+
+	// Attach 尝试让新元素附着在现有元素集合内，此时不触发元素反应，返回尝试附着后的元素集合
+	Attach(originalElements []enum.ElementType, newElement enum.ElementType) (resultElements []enum.ElementType)
+
+	// Relative 判断某种反应是否是某元素的相关反应
+	Relative(reaction enum.Reaction, relativeElement enum.ElementType) bool
+}
+
+var (
+	nullReactionCalculator ReactionCalculator = nil
+)
+
+type RuleSet interface {
+	ImplementationCheck() bool
+	ReactionCalculator() ReactionCalculator
+}
+
+type ruleSet struct {
+	reactionCalculator ReactionCalculator
+}
+
+func (r ruleSet) ImplementationCheck() bool {
+	if r.reactionCalculator == nullReactionCalculator {
+		return false
+	}
+
+	return true
+}
+
+func (r ruleSet) ReactionCalculator() ReactionCalculator {
+	return r.reactionCalculator
+}
+
+func NewEmptyRuleSet() RuleSet {
+	return ruleSet{
+		reactionCalculator: nil,
+	}
+}
+
+func NewRuleSet(
+	elementalReactionCalculator ReactionCalculator,
+) RuleSet {
+	return ruleSet{
+		reactionCalculator: elementalReactionCalculator,
+	}
+}

--- a/main.go
+++ b/main.go
@@ -91,10 +91,12 @@ func (d DefenceBuff) EffectLeft() uint {
 }
 
 func main() {
-	ganyu1 := entity.NewCharacter(1, Ganyu{id: 2333})
+	ruleSet := entity.NewEmptyRuleSet()
+
+	ganyu1 := entity.NewCharacter(1, Ganyu{id: 2333}, ruleSet)
 	fmt.Printf("initializing characters: %+v\n", ganyu1)
 
-	ganyu2 := entity.NewCharacter(2, Ganyu{id: 3333})
+	ganyu2 := entity.NewCharacter(2, Ganyu{id: 3333}, ruleSet)
 	fmt.Printf("initializing characters: %+v\n", ganyu2)
 
 	modifiers := &context.ModifierContext{}

--- a/model/context/callback.go
+++ b/model/context/callback.go
@@ -11,6 +11,7 @@ type CallbackContext struct {
 	changeModifiers *ModifierContext
 	attachElement   map[uint]enum.ElementType
 	getCards        uint
+	findCard        kv.Pair[bool, enum.CardType]
 	switchCharacter kv.Pair[bool, uint]
 	operated        kv.Pair[bool, bool]
 }
@@ -33,6 +34,13 @@ func (c *CallbackContext) AttachElement(target uint, element enum.ElementType) {
 
 func (c *CallbackContext) GetCards(amount uint) {
 	c.getCards = amount
+}
+
+func (c *CallbackContext) FindCard(cardType enum.CardType) {
+	if !c.findCard.Key() {
+		c.findCard.SetKey(true)
+	}
+	c.findCard.SetValue(cardType)
 }
 
 func (c *CallbackContext) SwitchCharacter(target uint) {
@@ -67,6 +75,10 @@ func (c CallbackContext) AttachElementResult() map[uint]enum.ElementType {
 
 func (c CallbackContext) GetCardsResult() uint {
 	return c.getCards
+}
+
+func (c CallbackContext) GetFindCardResult() (find bool, cardType enum.CardType) {
+	return c.findCard.Key(), c.findCard.Value()
 }
 
 func (c CallbackContext) SwitchCharacterResult() (switched bool, target uint) {


### PR DESCRIPTION
完成了 [ #3 ](https://github.com/sunist-c/genius-invokation-simulator-backend/issues/3)，新增了`ReactionCalculator`，包括：

1. ReactionCalculate 计算当前角色身上附着的元素之间能否发生反应，返回反应类型和剩余元素
2. DamageCalculate 根据反应类型计算对应的伤害修正
3. EffectCalculate 根据反应类型计算对应的反应效果
4. Attach 尝试让新元素附着在现有元素集合内，此时不触发元素反应，返回尝试附着后的元素集合\
5. Relative 判断某种反应是否是某元素的相关反应