### PR TITLE
Basically complete entity.core

### DIFF
--- a/entity/character.go
+++ b/entity/character.go
@@ -51,6 +51,9 @@ type Character interface {
 	// MP 角色的当前MP
 	MP() uint
 
+	// HasSkill 角色是否持有id为skill的技能
+	HasSkill(skill uint) bool
+
 	// Status 角色的状态
 	Status() enum.CharacterStatus
 
@@ -92,6 +95,9 @@ type Character interface {
 
 	// ExecuteElementAttachment 判断角色能否附着attachElement元素并尝试进行附着，此时不触发元素反应
 	ExecuteElementAttachment(attachElement enum.ElementType)
+
+	// ExecuteElementReaction 尝试使用角色身上附着的元素进行反应，返回能否反应和反应类型
+	ExecuteElementReaction() (reaction enum.Reaction)
 }
 
 type character struct {
@@ -127,6 +133,10 @@ func (c *character) SwitchUp() {
 
 func (c *character) SwitchDown() {
 	c.status = enum.CharacterStatusBackground
+}
+
+func (c character) HasSkill(skill uint) bool {
+	return c.skills.Exists(skill)
 }
 
 func (c *character) ExecuteCharge(ctx *context.ChargeContext) {
@@ -289,6 +299,11 @@ func (c *character) ExecuteEatFood(ctx *context.ModifierContext) {
 
 func (c *character) ExecuteElementAttachment(attachElement enum.ElementType) {
 	c.elements = c.ruleSet.ReactionCalculator().Attach(c.elements, attachElement)
+}
+
+func (c *character) ExecuteElementReaction() (reaction enum.Reaction) {
+	reaction, c.elements = c.ruleSet.ReactionCalculator().ReactionCalculate(c.elements)
+	return reaction
 }
 
 func (c character) ID() uint {

--- a/entity/character.go
+++ b/entity/character.go
@@ -96,7 +96,7 @@ type Character interface {
 	// ExecuteElementAttachment 判断角色能否附着attachElement元素并尝试进行附着，此时不触发元素反应
 	ExecuteElementAttachment(attachElement enum.ElementType)
 
-	// ExecuteElementReaction 尝试使用角色身上附着的元素进行反应，返回能否反应和反应类型
+	// ExecuteElementReaction 尝试使用角色身上附着的元素进行反应，返回反应类型
 	ExecuteElementReaction() (reaction enum.Reaction)
 }
 

--- a/entity/core.go
+++ b/entity/core.go
@@ -1,6 +1,7 @@
 package entity
 
 import (
+	"github.com/sunist-c/genius-invokation-simulator-backend/enum"
 	"github.com/sunist-c/genius-invokation-simulator-backend/model/kv"
 )
 
@@ -50,17 +51,14 @@ func newPlayerChain() *playerChain {
 	}
 }
 
-type Framework interface {
-}
-
-type core struct {
+type Core struct {
 	ruleSet     RuleSet
 	players     kv.Map[uint, Player]
 	activeChain *playerChain
 	nextChain   *playerChain
 }
 
-func (c *core) ExecuteAttack(sender uint, target uint, skill uint) {
+func (c *Core) ExecuteAttack(sender uint, target uint, skill uint) {
 	if c.players.Exists(sender) && c.players.Exists(target) {
 		senderPlayer, targetPlayer := c.players.Get(sender), c.players.Get(target)
 
@@ -94,4 +92,26 @@ func (c *core) ExecuteAttack(sender uint, target uint, skill uint) {
 			targetPlayer.ExecuteAfterDefenceCallback()
 		}
 	}
+}
+
+func (c *Core) ExecuteBurnCard(sender uint, card uint, exchangeElement enum.ElementType) {
+	if c.players.Exists(sender) {
+		c.players.Get(sender).ExecuteBurnCard(card, exchangeElement)
+	}
+}
+
+func NewCore(rule RuleSet, players []Player) *Core {
+	core := &Core{
+		ruleSet:     rule,
+		players:     kv.NewSimpleMap[Player](),
+		activeChain: newPlayerChain(),
+		nextChain:   newPlayerChain(),
+	}
+
+	for _, player := range players {
+		core.activeChain.add(player)
+		core.players.Set(player.UID(), player)
+	}
+
+	return core
 }

--- a/entity/framework.go
+++ b/entity/framework.go
@@ -1,0 +1,101 @@
+package entity
+
+import (
+	"github.com/sunist-c/genius-invokation-simulator-backend/enum"
+	"github.com/sunist-c/genius-invokation-simulator-backend/model/kv"
+)
+
+type playerChain struct {
+	canOperated kv.Map[uint, bool]
+	queue       []uint
+	offset      int
+}
+
+func (pc *playerChain) next() (has bool, player uint) {
+	for i := pc.offset; i < len(pc.queue); i++ {
+		if pc.canOperated.Get(pc.queue[i]) {
+			pc.offset = i + 1
+			return true, pc.queue[i]
+		}
+	}
+	for i := 0; i < pc.offset; i++ {
+		if pc.canOperated.Get(pc.queue[i]) {
+			pc.offset = i + 1
+			return true, pc.queue[i]
+		}
+	}
+
+	return false, 0
+}
+
+func (pc *playerChain) complete(player uint) {
+	pc.canOperated.Set(player, false)
+}
+
+func (pc *playerChain) empty() {
+	pc.canOperated = kv.NewSimpleMap[bool]()
+	pc.queue = []uint{}
+	pc.offset = 0
+}
+
+func (pc *playerChain) add(player Player) {
+	pc.canOperated.Set(player.UID(), true)
+	pc.queue = append(pc.queue, player.UID())
+}
+
+func newPlayerChain() *playerChain {
+	return &playerChain{
+		canOperated: kv.NewSimpleMap[bool](),
+		queue:       []uint{},
+		offset:      0,
+	}
+}
+
+type Framework interface {
+}
+
+type framework struct {
+	ruleSet     RuleSet
+	players     kv.Map[uint, Player]
+	activeChain *playerChain
+	nextChain   *playerChain
+}
+
+func (f *framework) ExecuteAttack(sender uint, target uint, skill uint) {
+	if f.players.Exists(sender) && f.players.Exists(target) {
+		senderPlayer, targetPlayer := f.players.Get(sender), f.players.Get(target)
+
+		if has, character := senderPlayer.GetActiveCharacter(); has && character.HasSkill(skill) {
+			// 填充DamageContext
+			_, targetCharacter := targetPlayer.GetActiveCharacter()
+			backgroundCharacters := targetPlayer.GetBackgroundCharacters()
+			background := make([]uint, len(backgroundCharacters))
+			for i, backgroundCharacter := range backgroundCharacters {
+				background[i] = backgroundCharacter.ID()
+			}
+			ctx := senderPlayer.ExecuteAttack(skill, targetCharacter.ID(), background)
+
+			// 执行攻击流程
+			senderPlayer.ExecuteDirectAttackModifiers(ctx)
+			targetPlayer.ExecuteElementAttachment(ctx)
+			activeReaction := enum.ReactionNone
+			for targetCharacterID := range ctx.Damage() {
+				_, c := targetPlayer.GetCharacter(targetCharacterID)
+				reaction := c.ExecuteElementReaction()
+				if targetCharacterID == targetCharacter.ID() {
+					activeReaction = reaction
+				}
+				f.ruleSet.ReactionCalculator().DamageCalculate(reaction, targetCharacterID, ctx)
+			}
+			senderPlayer.ExecuteFinalAttackModifiers(ctx)
+			targetPlayer.ExecuteDefence(ctx)
+			if event := f.ruleSet.ReactionCalculator().EffectCalculate(activeReaction); event != nil {
+				targetPlayer.ExecuteCallbackModify(event)
+			}
+
+			// 执行回调流程
+			senderPlayer.ExecuteAfterAttackCallback()
+			targetPlayer.ExecuteAfterDefenceCallback()
+		}
+	}
+}

--- a/entity/player.go
+++ b/entity/player.go
@@ -45,6 +45,7 @@ type Player interface {
 	GetActiveCharacter() (has bool, character Character)
 	GetCharacter(id uint) (has bool, character Character)
 	GetBackgroundCharacters() (characters []Character)
+	HoldingCard(card uint) (holding bool)
 	Defeated() bool
 }
 
@@ -134,6 +135,10 @@ func (p *player) GetBackgroundCharacters() (characters []Character) {
 	})
 
 	return characters
+}
+
+func (p player) HoldingCard(card uint) (holding bool) {
+	return p.holdingCards.Exists(card)
 }
 
 func (p *player) Defeated() bool {

--- a/entity/player.go
+++ b/entity/player.go
@@ -181,8 +181,8 @@ func (p *player) SwitchNextCharacter() {
 func (p *player) SwitchPrevCharacter() {
 	// notice: 如果只有一人，此处不进行切换
 	index := p.characters.GetIndex(p.activeCharacter)
-	for i := index - 1; i >= 0; i-- {
-		if character := p.characters.Get(p.characters.GetKey(i)); character.Status() != enum.CharacterStatusDefeated {
+	for i := int(index - 1); i >= 0; i-- {
+		if character := p.characters.Get(p.characters.GetKey(uint(i))); character.Status() != enum.CharacterStatusDefeated {
 			p.SwitchCharacter(character.ID())
 			return
 		}

--- a/entity/rule.go
+++ b/entity/rule.go
@@ -10,7 +10,7 @@ type ReactionCalculator interface {
 	ReactionCalculate([]enum.ElementType) (reaction enum.Reaction, elementRemains []enum.ElementType)
 
 	// DamageCalculate 根据反应类型计算对应的伤害修正
-	DamageCalculate(reaction enum.Reaction, ctx *context.DamageContext)
+	DamageCalculate(reaction enum.Reaction, targetCharacter uint, ctx *context.DamageContext)
 
 	// EffectCalculate 根据反应类型计算对应的反应效果
 	EffectCalculate(reaction enum.Reaction) (ctx *context.CallbackContext)

--- a/entity/rule.go
+++ b/entity/rule.go
@@ -13,7 +13,7 @@ type ReactionCalculator interface {
 	DamageCalculate(reaction enum.Reaction, targetCharacter uint, ctx *context.DamageContext)
 
 	// EffectCalculate 根据反应类型计算对应的反应效果
-	EffectCalculate(reaction enum.Reaction) (ctx *context.CallbackContext)
+	EffectCalculate(reaction enum.Reaction, targetPlayer Player) (ctx *context.CallbackContext)
 
 	// Attach 尝试让新元素附着在现有元素集合内，此时不触发元素反应，返回尝试附着后的元素集合
 	Attach(originalElements []enum.ElementType, newElement enum.ElementType) (resultElements []enum.ElementType)

--- a/entity/rule.go
+++ b/entity/rule.go
@@ -36,11 +36,7 @@ type ruleSet struct {
 }
 
 func (r ruleSet) ImplementationCheck() bool {
-	if r.reactionCalculator == nullReactionCalculator {
-		return false
-	}
-
-	return true
+	return r.reactionCalculator != nullReactionCalculator
 }
 
 func (r ruleSet) ReactionCalculator() ReactionCalculator {

--- a/enum/trigger.go
+++ b/enum/trigger.go
@@ -5,6 +5,7 @@ type TriggerType byte
 
 const (
 	AfterAttack     TriggerType = iota // AfterAttack 攻击结算后触发
+	AfterBurnCard                      // AfterBurnCard 使用卡牌转换元素后触发
 	AfterCharge                        // AfterCharge 充能后触发
 	AfterDefence                       // AfterDefence 防御结算后触发
 	AfterEatFood                       // AfterEatFood 使用食物后触发

--- a/model/context/callback.go
+++ b/model/context/callback.go
@@ -6,34 +6,51 @@ import (
 )
 
 type CallbackContext struct {
-	changeElements  *CostContext
-	changeCharge    *ChargeContext
-	changeModifiers *ModifierContext
-	attachElement   map[uint]enum.ElementType
-	getCards        uint
+	changeElements  kv.Pair[bool, *CostContext]
+	changeCharge    kv.Pair[bool, *ChargeContext]
+	changeModifiers kv.Pair[bool, *ModifierContext]
+	attachElement   kv.Pair[bool, map[uint]enum.ElementType]
+	getCards        kv.Pair[bool, uint]
 	findCard        kv.Pair[bool, enum.CardType]
 	switchCharacter kv.Pair[bool, uint]
 	operated        kv.Pair[bool, bool]
 }
 
 func (c *CallbackContext) ChangeElements(f func(ctx *CostContext)) {
-	f(c.changeElements)
+	if !c.changeElements.Key() {
+		c.changeElements.SetKey(true)
+	}
+	f(c.changeElements.Value())
 }
 
 func (c *CallbackContext) ChangeCharge(f func(ctx *ChargeContext)) {
-	f(c.changeCharge)
+	if !c.changeCharge.Key() {
+		c.changeCharge.SetKey(true)
+	}
+	f(c.changeCharge.Value())
 }
 
 func (c *CallbackContext) ChangeModifiers(f func(ctx *ModifierContext)) {
-	f(c.changeModifiers)
+	if !c.changeModifiers.Key() {
+		c.changeModifiers.SetKey(true)
+	}
+	f(c.changeModifiers.Value())
 }
 
 func (c *CallbackContext) AttachElement(target uint, element enum.ElementType) {
-	c.attachElement[target] = element
+	if !c.attachElement.Key() {
+		c.attachElement.SetKey(true)
+	}
+	value := c.attachElement.Value()
+	value[target] = element
+	c.attachElement.SetValue(value)
 }
 
 func (c *CallbackContext) GetCards(amount uint) {
-	c.getCards = amount
+	if !c.getCards.Key() {
+		c.getCards.SetKey(true)
+	}
+	c.getCards.SetValue(amount)
 }
 
 func (c *CallbackContext) FindCard(cardType enum.CardType) {
@@ -57,24 +74,24 @@ func (c *CallbackContext) ChangeOperated(operated bool) {
 	c.operated.SetValue(operated)
 }
 
-func (c CallbackContext) ChangeElementsResult() CostContext {
-	return *c.changeElements
+func (c CallbackContext) ChangeElementsResult() (changed bool, result *CostContext) {
+	return c.changeElements.Key(), c.changeElements.Value()
 }
 
-func (c CallbackContext) ChangeChargeResult() ChargeContext {
-	return *c.changeCharge
+func (c CallbackContext) ChangeChargeResult() (changed bool, result *ChargeContext) {
+	return c.changeCharge.Key(), c.changeCharge.Value()
 }
 
-func (c CallbackContext) ChangeModifiersResult() ModifierContext {
-	return *c.changeModifiers
+func (c CallbackContext) ChangeModifiersResult() (changed bool, result *ModifierContext) {
+	return c.changeModifiers.Key(), c.changeModifiers.Value()
 }
 
-func (c CallbackContext) AttachElementResult() map[uint]enum.ElementType {
-	return c.attachElement
+func (c CallbackContext) AttachElementResult() (changed bool, result map[uint]enum.ElementType) {
+	return c.attachElement.Key(), c.attachElement.Value()
 }
 
-func (c CallbackContext) GetCardsResult() uint {
-	return c.getCards
+func (c CallbackContext) GetCardsResult() (changed bool, result uint) {
+	return c.getCards.Key(), c.getCards.Value()
 }
 
 func (c CallbackContext) GetFindCardResult() (find bool, cardType enum.CardType) {
@@ -91,12 +108,13 @@ func (c CallbackContext) ChangeOperatedResult() (switched, operated bool) {
 
 func NewCallbackContext() *CallbackContext {
 	return &CallbackContext{
-		changeElements:  NewCostContext(),
-		changeCharge:    NewChargeContext(),
-		changeModifiers: NewModifierContext(),
-		attachElement:   map[uint]enum.ElementType{},
-		getCards:        0,
+		changeElements:  kv.NewPair(false, NewCostContext()),
+		changeCharge:    kv.NewPair(false, NewChargeContext()),
+		changeModifiers: kv.NewPair(false, NewModifierContext()),
+		attachElement:   kv.NewPair(false, map[uint]enum.ElementType{}),
+		getCards:        kv.NewPair(false, uint(0)),
 		switchCharacter: kv.NewPair(false, uint(0)),
 		operated:        kv.NewPair(false, false),
+		findCard:        kv.NewPair(false, enum.CardType(0)),
 	}
 }

--- a/model/context/damage.go
+++ b/model/context/damage.go
@@ -6,6 +6,7 @@ import (
 
 type Damage struct {
 	elementType enum.ElementType
+	reaction    enum.Reaction
 	amount      uint
 }
 
@@ -33,6 +34,11 @@ func (d Damage) Amount() uint {
 // ElementType 伤害的元素类型，只读
 func (d Damage) ElementType() enum.ElementType {
 	return d.elementType
+}
+
+// Reaction 伤害发生的反应，只读
+func (d Damage) Reaction() enum.Reaction {
+	return d.reaction
 }
 
 type DamageContext struct {
@@ -72,8 +78,28 @@ func (d *DamageContext) ChangeElementType(element enum.ElementType) {
 	d.damages[d.targetCharacter].change(element)
 }
 
+// SetReaction 目标角色身上发生的元素反应类型，仅供框架使用
+func (d *DamageContext) SetReaction(targetCharacter uint, reaction enum.Reaction) {
+	d.damages[targetCharacter].reaction = reaction
+}
+
+// GetTargetCharacter 获取伤害的目标角色ID
+func (d DamageContext) GetTargetCharacter() uint {
+	return d.targetCharacter
+}
+
+// GetBackgroundCharacters 获取伤害的目标后台角色ID
+func (d DamageContext) GetBackgroundCharacters() []uint {
+	return d.backgroundCharacters
+}
+
+// GetTargetCharacterReaction 获取伤害的目标角色发生的元素反应
+func (d DamageContext) GetTargetCharacterReaction() enum.Reaction {
+	return d.damages[d.targetCharacter].reaction
+}
+
 // Damage 返回DamageContext携带的伤害信息，只读
-func (d *DamageContext) Damage() map[uint]Damage {
+func (d DamageContext) Damage() map[uint]Damage {
 	result := map[uint]Damage{}
 	for _, id := range d.backgroundCharacters {
 		result[id] = Damage{elementType: enum.ElementNone, amount: 0}
@@ -104,6 +130,6 @@ func NewDamageContext(skill, from, target uint, backgrounds []uint, elementType 
 		sendPlayer:           from,
 		targetCharacter:      target,
 		backgroundCharacters: backgrounds,
-		damages:              map[uint]*Damage{target: &Damage{elementType: elementType, amount: damageAmount}},
+		damages:              map[uint]*Damage{target: {elementType: elementType, amount: damageAmount, reaction: enum.ReactionNone}},
 	}
 }

--- a/model/context/damage.go
+++ b/model/context/damage.go
@@ -75,6 +75,10 @@ func (d *DamageContext) ChangeElementType(element enum.ElementType) {
 // Damage 返回DamageContext携带的伤害信息，只读
 func (d *DamageContext) Damage() map[uint]Damage {
 	result := map[uint]Damage{}
+	for _, id := range d.backgroundCharacters {
+		result[id] = Damage{elementType: enum.ElementNone, amount: 0}
+	}
+
 	for target, damage := range d.damages {
 		result[target] = *damage
 	}


### PR DESCRIPTION
完成了 #5 的部分内容，主要更新内容包括：

1. entity.core的攻击、元素转换逻辑与构造方法
2. 更新了callback的实际执行逻辑，加入了修改检查，避免了重复的额外回调触发
3. 更新了main.go中的战斗demo，使用了entity.core进行操作而不是直接对character进行操作
4. 更新了context.Damage的结构，把会发生的元素反应加入了DamageContext
5. 更新了ReactionCalculator的接口定义，使ReactionCalculator.EffectCalculate可以更精准地生成event