### PR TITLE
Finish persistence module in #8, fix #16

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -34,7 +34,7 @@ steps:
       pull: if-not-exist
       commands:
           - go mod tidy
-          - go test -bench=. -benchtime=10s ./... -run=^$
+          - go test -bench=. -benchtime=1s ./... -run=^$
 
     - name: feishu notification
       image: serialt/drone-feishu-message

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,4 +21,4 @@ jobs:
         run: go mod tidy && go test -v ./...
 
       - name: BenchmarkTest
-        run: go mod tidy && go test -bench=. -benchtime=10s ./... -run=^$
+        run: go mod tidy && go test -bench=. -benchtime=1s ./... -run=^$

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,12 @@
+# go-plugin的插件文件
+*.so
+
+# 可能的配置文件
+*.json
+*.xml
+*.yml
+
+# 持久化文件
+*.psc
+*.psc.quit
+*.db

--- a/data/persistence/.gitignore
+++ b/data/persistence/.gitignore
@@ -1,4 +1,0 @@
-*.so
-*.json
-*.xml
-*.yml

--- a/enum/language.go
+++ b/enum/language.go
@@ -1,0 +1,15 @@
+package enum
+
+type Language uint
+
+const (
+	ChineseSimplified  Language = iota // ChineseSimplified 简体中文
+	ChineseTraditional                 // ChineseTraditional 繁體中文
+	English                            // English
+	French                             // French Français
+	German                             // German Deutsch
+	Japanese                           // Japanese 日本語
+	Korean                             // Korean 한국어
+	Russian                            // Russian Русский язык
+	Unknown                            // Unknown ያንሽቤ
+)

--- a/enum/stage.go
+++ b/enum/stage.go
@@ -1,0 +1,12 @@
+package enum
+
+// RoundStage 回合生命周期
+type RoundStage byte
+
+const (
+	RoundStageInitialized RoundStage = iota // RoundStageInitialized 初始化完成阶段，仅在游戏开始时进入
+	RoundStageStart                         // RoundStageStart 回合开始阶段
+	RoundStageRoll                          // RoundStageRoll 投掷阶段
+	RoundStageBattle                        // RoundStageBattle 对战阶段
+	RoundStageEnd                           // RoundStageEnd 回合结束阶段
+)

--- a/exec/backend/main.go
+++ b/exec/backend/main.go
@@ -1,6 +1,13 @@
 package backend
 
+import "github.com/sunist-c/genius-invokation-simulator-backend/protocol/http"
+
 func Run(port uint) {
+	errChan := make(chan error)
+	http.Serve(port, errChan)
+
+	err := <-errChan
+	panic(err)
 }
 
 func Quit() {}

--- a/exec/cli/main.go
+++ b/exec/cli/main.go
@@ -1,9 +1,25 @@
 package cli
 
-import "time"
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
 
 func Run() {
-	time.Sleep(time.Second * 114514)
+	for {
+		if input, _, err := bufio.NewReader(os.Stdin).ReadLine(); err != nil {
+			fmt.Printf("[cli.log] error occurred in cli.Run() %v\n", err)
+			time.Sleep(time.Second)
+		} else {
+			if strings.Split(string(input), " ")[0] == "exit" {
+				break
+			}
+			fmt.Printf("%+v\n", string(input))
+		}
+	}
 }
 
 func Quit() {}

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,28 @@ module github.com/sunist-c/genius-invokation-simulator-backend
 go 1.19
 
 require (
+	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/gin-gonic/gin v1.8.2 // indirect
+	github.com/go-playground/locales v0.14.1 // indirect
+	github.com/go-playground/universal-translator v0.18.0 // indirect
+	github.com/go-playground/validator/v10 v10.11.1 // indirect
 	github.com/go-xorm/xorm v0.7.9 // indirect
+	github.com/goccy/go-json v0.10.0 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/leodido/go-urn v1.2.1 // indirect
+	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mattn/go-sqlite3 v1.14.16 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
+	github.com/satori/go.uuid v1.2.0 // indirect
+	github.com/ugorji/go/codec v1.2.8 // indirect
+	golang.org/x/crypto v0.5.0 // indirect
+	golang.org/x/net v0.5.0 // indirect
+	golang.org/x/sys v0.4.0 // indirect
+	golang.org/x/text v0.6.0 // indirect
+	google.golang.org/protobuf v1.28.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	xorm.io/builder v0.3.12 // indirect
 	xorm.io/core v0.7.3 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ type argument struct {
 func initArgs() {
 	flag.StringVar(args.conf, "conf", "", "setup the backend configuration file, highest priority")
 	flag.StringVar(args.mode, "mode", "backend", "setup the startup mode, available [backend, cli, ai]")
-	flag.UintVar(args.port, "port", 8086, "setup the http service port")
+	flag.UintVar(args.port, "port", 8086, "setup the http protocol port")
 	flag.BoolVar(args.save, "save", true, "setup if to enable the persistence module")
 	flag.StringVar(args.storage, "storage", path.Join(os.Args[0], "../data/persistence"), "setup the persistence storage filepath")
 	flag.UintVar(args.flush, "flush", 3600, "setup the flush frequency(second) of persistence module")
@@ -63,7 +63,7 @@ func callQuit() {
 	case cliMode:
 		cli.Quit()
 	case aiMode:
-
+		panic("not implemented yet")
 	}
 
 	fmt.Printf("[main.log] main.callQuit(): wait 10 seconds for quit task\n")

--- a/main.go
+++ b/main.go
@@ -8,7 +8,9 @@ import (
 	"github.com/sunist-c/genius-invokation-simulator-backend/persistence"
 	"os"
 	"os/signal"
+	"path"
 	"syscall"
+	"time"
 )
 
 const (
@@ -19,19 +21,23 @@ const (
 
 var (
 	args = &argument{
-		mode: new(string),
-		port: new(uint),
-		conf: new(string),
-		save: new(bool),
+		mode:    new(string),
+		port:    new(uint),
+		conf:    new(string),
+		save:    new(bool),
+		flush:   new(uint),
+		storage: new(string),
 	}
 	sig = make(chan os.Signal, 4)
 )
 
 type argument struct {
-	mode *string
-	conf *string
-	port *uint
-	save *bool
+	mode    *string
+	conf    *string
+	port    *uint
+	save    *bool
+	flush   *uint
+	storage *string
 }
 
 func initArgs() {
@@ -39,6 +45,8 @@ func initArgs() {
 	flag.StringVar(args.mode, "mode", "backend", "setup the startup mode, available [backend, cli, ai]")
 	flag.UintVar(args.port, "port", 8086, "setup the http service port")
 	flag.BoolVar(args.save, "save", true, "setup if to enable the persistence module")
+	flag.StringVar(args.storage, "storage", path.Join(os.Args[0], "../data/persistence"), "setup the persistence storage filepath")
+	flag.UintVar(args.flush, "flush", 3600, "setup the flush frequency(second) of persistence module")
 }
 
 func callQuit() {
@@ -58,26 +66,33 @@ func callQuit() {
 
 	}
 
-	fmt.Printf("[main.log] main.callQuit(): quited with code 114\n")
+	fmt.Printf("[main.log] main.callQuit(): wait 10 seconds for quit task\n")
+	time.Sleep(time.Second * 10)
 	os.Exit(114)
 }
 
 func init() {
+	errChan := make(chan error, 10)
 	fmt.Printf("[main.log] main.init(): initializing main package\n")
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGHUP)
 	fmt.Printf("[main.log] main.init(): setuped signal channel\n")
 	initArgs()
 	flag.Parse()
 	fmt.Printf("[main.log] main.init(): parsed command line arguments\n")
-	_ = persistence.SetStoragePath("/Users/sunist/Projects/GitHub/gisb/data/persistence")
-	ch := make(chan error, 10)
-	persistence.Load(ch)
+	if err := persistence.SetStoragePath(*args.storage); err != nil {
+		errChan <- err
+		panic(err)
+	}
+	fmt.Printf("[main.log] main.init(): initialized storage path\n")
+	persistence.Load(errChan)
 	fmt.Printf("[main.log] main.init(): initializing persistent storage\n")
 	go func() {
-		for err := range ch {
+		fmt.Printf("[main.log] main.errorHandler(): error handler running\n")
+		for err := range errChan {
 			fmt.Println(err)
 		}
 	}()
+	persistence.Serve(time.Second*time.Duration(*args.flush), errChan)
 	fmt.Printf("[main.log] main.init(): initialize completed\n")
 }
 

--- a/model/localization/language.go
+++ b/model/localization/language.go
@@ -1,0 +1,51 @@
+package localization
+
+import "github.com/sunist-c/genius-invokation-simulator-backend/enum"
+
+type MultipleLanguagePack struct {
+	Languages          map[enum.Language]map[string]string
+	SupportedLanguages []enum.Language
+}
+
+// LanguagePack 语言包接口
+type LanguagePack interface {
+	Translate(original string, destLanguage enum.Language) (ok bool, result string)
+	Pack() MultipleLanguagePack
+}
+
+// languagePack 语言包
+type languagePack struct {
+	translations map[enum.Language]map[string]string
+	languages    []enum.Language
+}
+
+func (l languagePack) Translate(original string, destLanguage enum.Language) (ok bool, result string) {
+	if pack, hasLanguage := l.translations[destLanguage]; !hasLanguage {
+		return false, ""
+	} else {
+		result, ok = pack[original]
+		return ok, result
+	}
+}
+
+func (l languagePack) Pack() MultipleLanguagePack {
+	pack := MultipleLanguagePack{
+		Languages:          l.translations,
+		SupportedLanguages: l.languages,
+	}
+
+	return pack
+}
+
+func NewLanguagePack(translations map[enum.Language]map[string]string) LanguagePack {
+	pack := languagePack{
+		translations: translations,
+		languages:    []enum.Language{},
+	}
+
+	for language := range translations {
+		pack.languages = append(pack.languages, language)
+	}
+
+	return pack
+}

--- a/model/message/sync.go
+++ b/model/message/sync.go
@@ -32,6 +32,25 @@ type CooperativeSkill struct {
 	Trigger enum.TriggerType `json:"trigger" yaml:"trigger" xml:"trigger"` // Trigger 协同攻击的触发条件
 }
 
+// Summon 召唤物信息
+type Summon struct {
+	ID     uint `json:"id" yaml:"id" xml:"id"`             // ID 召唤物的ID
+	Remain uint `json:"remain" yaml:"remain" xml:"remain"` // Remain 召唤物剩余可生效次数
+}
+
+// Support 支援物信息
+type Support struct {
+	ID     uint `json:"id" yaml:"id" xml:"id"`             // ID 支援物的ID
+	Remain uint `json:"remain" yaml:"remain" xml:"remain"` // Remain 支援物的剩余可生效次数
+}
+
+// Game 对局的信息
+type Game struct {
+	ActingPlayer uint            `json:"acting_player" yaml:"acting_player" xml:"acting_player"` // ActingPlayer 当前正在操作的玩家
+	RoundStage   enum.RoundStage `json:"round_stage" yaml:"round_stage" xml:"round_stage"`       // RoundStage 当前的回合阶段
+	RoundCount   uint            `json:"round_count" yaml:"round_count" xml:"round_count"`       // RoundCount 当前的回合数
+}
+
 // Event 事件信息
 type Event struct {
 	ID      uint             `json:"id" yaml:"id" xml:"id"`                // ID 事件的实体ID
@@ -50,13 +69,16 @@ type Character struct {
 
 // Base 基础玩家信息
 type Base struct {
-	UID          uint               `json:"uid" yaml:"uid" xml:"uid"`                            // UID 玩家的UID
-	Characters   []Character        `json:"characters" yaml:"characters" xml:"characters"`       // Characters 玩家的持有角色
-	CampEffect   []Modifier         `json:"camp_effect" yaml:"camp_effect" xml:"camp_effect"`    // CampEffect 玩家的阵营效果
-	Cooperatives []CooperativeSkill `json:"cooperatives" yaml:"cooperatives" xml:"cooperatives"` // Cooperatives 玩家可进行的协同攻击
-	Events       []Event            `json:"events" yaml:"events" xml:"events"`                   // Events 玩家身上的事件
-	RemainCards  uint               `json:"remain_cards" yaml:"remain_cards" xml:"remain_cards"` // RemainCards 玩家牌堆剩余的数量
-	Status       enum.PlayerStatus  `json:"status" yaml:"status" xml:"status"`                   // Status 玩家的状态信息
+	UID          uint               `json:"uid" yaml:"uid" xml:"uid"`                               // UID 玩家的UID
+	Characters   []Character        `json:"characters" yaml:"characters" xml:"characters"`          // Characters 玩家的持有角色
+	CampEffect   []Modifier         `json:"camp_effect" yaml:"camp_effect" xml:"camp_effect"`       // CampEffect 玩家的阵营效果
+	Cooperatives []CooperativeSkill `json:"cooperatives" yaml:"cooperatives" xml:"cooperatives"`    // Cooperatives 玩家可进行的协同攻击
+	Summons      []Summon           `json:"summons" yaml:"summons" xml:"summons"`                   // Summons 玩家持有的召唤物
+	Supports     []Support          `json:"supports" yaml:"supports" xml:"supports"`                // Supports 玩家持有的支援效果
+	Events       []Event            `json:"events" yaml:"events" xml:"events"`                      // Events 玩家身上的事件
+	RemainCards  uint               `json:"remain_cards" yaml:"remain_cards" xml:"remain_cards"`    // RemainCards 玩家牌堆剩余的数量
+	LegalActions []enum.ActionType  `json:"legal_actions" yaml:"legal_actions" xml:"legal_actions"` // LegalActions 当前的合法操作
+	Status       enum.PlayerStatus  `json:"status" yaml:"status" xml:"status"`                      // Status 玩家的状态信息
 }
 
 // Self 接收玩家自己的信息
@@ -75,6 +97,7 @@ type Other struct {
 
 // SyncMessage 玩家接收到的同步消息
 type SyncMessage struct {
+	Game    Game        `json:"game" yaml:"game" xml:"game"`          // Game 对局信息
 	Target  uint        `json:"target"   yaml:"target" xml:"target"`  // Target 接收同步消息的玩家
 	Message interface{} `json:"message" yaml:"message" xml:"message"` // Message 同步消息
 }
@@ -99,8 +122,9 @@ type GuestMessage struct {
 }
 
 // NewSyncMessage 创建一个指定接收者的同步信息
-func NewSyncMessage[message SyncMessageInterface](target uint, msg message) SyncMessage {
+func NewSyncMessage[message SyncMessageInterface](target uint, msg message, game Game) SyncMessage {
 	return SyncMessage{
+		Game:    game,
 		Target:  target,
 		Message: msg,
 	}

--- a/persistence/db.go
+++ b/persistence/db.go
@@ -127,22 +127,24 @@ type persistence[T any] struct {
 
 func (p *persistence[T]) Serve(flushFrequency time.Duration, flushPath, flushFile string, errChan chan error) {
 	go func() {
-		for {
-			select {
-			case <-p.exit:
-				// 收到退出信号，立即将缓存写入文件
-				if err := p.Flush(flushPath, strings.Join([]string{flushFile, "quick"}, ".")); err != nil {
-					errChan <- err
-				}
-				return
-			default:
+		// 执行定时任务
+		go func() {
+			for {
 				// 每隔flushFrequency，将缓存写入文件
-				time.Sleep(flushFrequency)
 				if err := p.Flush(flushPath, flushFile); err != nil {
 					errChan <- err
 				}
+				time.Sleep(flushFrequency)
 			}
+		}()
+
+		// 监听exit信号
+		<-p.exit
+		// 收到退出信号，立即将缓存写入文件
+		if err := p.Flush(flushPath, strings.Join([]string{flushFile, "quit"}, ".")); err != nil {
+			errChan <- err
 		}
+		return
 	}()
 }
 

--- a/persistence/db.go
+++ b/persistence/db.go
@@ -145,11 +145,9 @@ func (p *persistence[T]) Serve(flushFrequency time.Duration, flushPath, flushFil
 		}(exitCh)
 
 		// 监听exit信号
-		fmt.Printf("wait for exit signal\n")
 		<-p.exit
 		exitCh <- struct{}{}
 		// 收到退出信号，立即将缓存写入文件
-		fmt.Printf("quiting\n")
 		if err := p.Flush(flushPath, strings.Join([]string{flushFile, "quit"}, ".")); err != nil {
 			errChan <- err
 		}

--- a/persistence/model.go
+++ b/persistence/model.go
@@ -3,6 +3,7 @@ package persistence
 import (
 	"github.com/sunist-c/genius-invokation-simulator-backend/entity"
 	"github.com/sunist-c/genius-invokation-simulator-backend/enum"
+	"github.com/sunist-c/genius-invokation-simulator-backend/model/localization"
 )
 
 // Card 被持久化模块托管的Card工厂
@@ -45,4 +46,11 @@ type CardDeck struct {
 	OwnerUID   uint   `xorm:"notnull index"`
 	Cards      []uint `xorm:"notnull json"`
 	Characters []uint `xorm:"notnull json"`
+}
+
+// Localization 被持久化模块托管的本地化信息工厂
+type Localization struct {
+	EntityID         uint
+	EntityUID        string
+	MultipleLanguage localization.LanguagePack
 }

--- a/protocol/http/engine.go
+++ b/protocol/http/engine.go
@@ -1,0 +1,28 @@
+package http
+
+import (
+	"fmt"
+	"github.com/gin-gonic/gin"
+)
+
+var nullHttpEngine *gin.Engine = nil
+
+var (
+	httpEngine *gin.Engine
+)
+
+func init() {
+	httpEngine = gin.Default()
+}
+
+func registerServices() {
+	if httpEngine == nullHttpEngine {
+		panic(nil)
+	}
+}
+
+func Serve(port uint, errChan chan error) {
+	if err := httpEngine.Run(fmt.Sprintf("0.0.0.0:%v", port)); err != nil {
+		errChan <- err
+	}
+}

--- a/protocol/http/middleware/qps.go
+++ b/protocol/http/middleware/qps.go
@@ -1,0 +1,62 @@
+package middleware
+
+import (
+	"fmt"
+	"github.com/gin-gonic/gin"
+	"github.com/sunist-c/genius-invokation-simulator-backend/model/kv"
+	"github.com/sunist-c/genius-invokation-simulator-backend/protocol/http/util"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func convertIPToUint(ip string) (success bool, result uint) {
+	splits := strings.Split(ip, ".")
+	if len(splits) != 4 {
+		return false, 0
+	} else {
+		for _, s := range splits {
+			if intResult, err := strconv.Atoi(s); err != nil {
+				return false, 0
+			} else if intResult > 256 || intResult < 0 {
+				return false, 0
+			} else {
+				result = result<<8 + uint(intResult)
+			}
+		}
+		return true, result
+	}
+}
+
+func convertUintToIP(ip uint) (result string) {
+	bytes := make([]byte, 4)
+	for i := 0; i < 4; i++ {
+		bytes[i] = byte(ip % 256)
+		ip = ip >> 8
+	}
+	return fmt.Sprintf("%d.%d.%d.%d", bytes[0], bytes[1], bytes[2], bytes[3])
+}
+
+// NewQPSLimiter 生成一个QPS限制器，以IP来源为基础
+func NewQPSLimiter(limit time.Duration) func(ctx *gin.Context) {
+	var limiter = kv.NewSyncMap[time.Time]()
+	return func(ctx *gin.Context) {
+		if success, ip := convertIPToUint(util.GetClientIP(ctx)); !success {
+			// 无法成功获取客户端IP，返回BadRequest
+			ctx.AbortWithStatus(400)
+		} else {
+			if limiter.Exists(ip) {
+				if t := limiter.Get(ip); !t.Add(limit).Before(time.Now()) {
+					// 请求过快，返回PreconditionFailed
+					ctx.AbortWithStatus(412)
+				} else {
+					// 正常请求，更新访问时间
+					limiter.Set(ip, time.Now())
+				}
+			} else {
+				// 之前未访问过，记录访问时间
+				limiter.Set(ip, time.Now())
+			}
+		}
+	}
+}

--- a/protocol/http/middleware/uuid.go
+++ b/protocol/http/middleware/uuid.go
@@ -1,0 +1,28 @@
+package middleware
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/sunist-c/genius-invokation-simulator-backend/util"
+)
+
+const (
+	uuidKey = "gisb/middleware.uuid"
+)
+
+// GetUUID 获取context中携带的uuid信息，若没有则生成并写入一个uuid
+func GetUUID(ctx *gin.Context) (uuid string) {
+	if result, gotten := ctx.Get(uuidKey); !gotten {
+		uuid = util.GenerateUUID()
+		ctx.Set(uuidKey, uuid)
+		return uuid
+	} else {
+		return result.(string)
+	}
+}
+
+// NewUUIDTagger 创建一个UUID标记器，将会往context中写入uuid
+func NewUUIDTagger() func(ctx *gin.Context) {
+	return func(ctx *gin.Context) {
+		ctx.Set("uuid", util.GenerateUUID())
+	}
+}

--- a/protocol/http/util/preprocess.go
+++ b/protocol/http/util/preprocess.go
@@ -1,0 +1,157 @@
+package util
+
+import (
+	"encoding/json"
+	"github.com/gin-gonic/gin"
+	"strconv"
+	"strings"
+)
+
+func convertToInt(source string) (success bool, result int) {
+	if intResult, err := strconv.Atoi(source); err != nil {
+		return false, 0
+	} else {
+		return true, intResult
+	}
+}
+
+func convertToFloat(source string) (success bool, result float64) {
+	if floatResult, err := strconv.ParseFloat(source, 64); err != nil {
+		return false, float64(0)
+	} else {
+		return true, floatResult
+	}
+}
+
+func convertToBool(source string) (success bool, result bool) {
+	if boolResult, err := strconv.ParseBool(source); err != nil {
+		return false, false
+	} else {
+		return true, boolResult
+	}
+}
+
+func convertToStruct[T any](source string) (success bool, result T) {
+	if err := json.Unmarshal([]byte(source), &result); err != nil {
+		return false, result
+	} else {
+		return true, result
+	}
+}
+
+// BindJson 将请求体中的数据绑定到给定的entity中，entity需要可寻址，失败直接返回BadRequest
+func BindJson[T any](ctx *gin.Context, entity T) {
+	if err := ctx.ShouldBindJSON(entity); err != nil {
+		ctx.AbortWithStatus(400)
+	}
+}
+
+// QueryPath 从URL进行查询，支持路径参数与查询参数
+func QueryPath(ctx *gin.Context, key string) (has bool, result string) {
+	if strings.HasPrefix(key, ":") {
+		result, has = ctx.Params.Get(strings.Trim(key, ":"))
+	} else {
+		result, has = ctx.GetQuery(key)
+	}
+
+	return has, result
+}
+
+// QueryPathInt 从URL中查询一个int类型的结果，调用QueryPath并进行转化
+func QueryPathInt(ctx *gin.Context, key string) (has bool, result int) {
+	if gotten, stringResult := QueryPath(ctx, key); !gotten {
+		return false, 0
+	} else {
+		return convertToInt(stringResult)
+	}
+}
+
+// QueryPathFloat 从URL中查询一个float64类型的结果，调QueryPathQueryPath并进行转化
+func QueryPathFloat(ctx *gin.Context, key string) (has bool, result float64) {
+	if gotten, stringResult := QueryPath(ctx, key); !gotten {
+		return false, float64(0)
+	} else {
+		return convertToFloat(stringResult)
+	}
+}
+
+// QueryPathBool 从URL中查询一个bool类型的结果，调QueryPathQueryPath并进行转化
+func QueryPathBool(ctx *gin.Context, key string) (has bool, result bool) {
+	if gotten, stringResult := QueryPath(ctx, key); !gotten {
+		return false, false
+	} else {
+		return convertToBool(stringResult)
+	}
+}
+
+// QueryPathJson 从URL中查询一个json对象，调用QueryPath并进行转化
+func QueryPathJson[T any](ctx *gin.Context, key string) (has bool, result T) {
+	if gotten, stringResult := QueryPath(ctx, key); !gotten {
+		return false, result
+	} else {
+		return convertToStruct[T](stringResult)
+	}
+}
+
+// QueryCookie 从cookie中获取指定key的值
+func QueryCookie(ctx *gin.Context, key string) (has bool, cookie string) {
+	if cookieResult, err := ctx.Cookie(key); err != nil {
+		return false, cookie
+	} else {
+		return true, cookieResult
+	}
+}
+
+// QueryHeaders 从请求头中获取指定key的值
+func QueryHeaders(ctx *gin.Context, key string) (has bool, result string) {
+	if result = ctx.GetHeader(key); result == "" {
+		return false, ""
+	} else {
+		return true, result
+	}
+}
+
+// QueryHeadersInt 从请求头中获取一个int类型的值
+func QueryHeadersInt(ctx *gin.Context, key string) (has bool, result int) {
+	if gotten, stringResult := QueryHeaders(ctx, key); !gotten {
+		return false, 0
+	} else {
+		return convertToInt(stringResult)
+	}
+}
+
+// QueryHeadersFloat 从请求头中获取一个float类型的值
+func QueryHeadersFloat(ctx *gin.Context, key string) (has bool, result float64) {
+	if gotten, stringResult := QueryHeaders(ctx, key); !gotten {
+		return false, float64(0)
+	} else {
+		return convertToFloat(stringResult)
+	}
+}
+
+// QueryHeadersBool 从请求头中获取一个bool类型的值
+func QueryHeadersBool(ctx *gin.Context, key string) (has bool, result bool) {
+	if gotten, stringResult := QueryHeaders(ctx, key); !gotten {
+		return false, false
+	} else {
+		return convertToBool(stringResult)
+	}
+}
+
+// QueryHeadersJson 从请求头中获取一个对象
+func QueryHeadersJson[T any](ctx *gin.Context, key string) (has bool, result T) {
+	if gotten, stringResult := QueryHeaders(ctx, key); !gotten {
+		return false, result
+	} else {
+		return convertToStruct[T](stringResult)
+	}
+}
+
+// GetClientIP 获取请求客户端的IP
+func GetClientIP(ctx *gin.Context) (result string) {
+	if addr := ctx.ClientIP(); addr == "::1" {
+		return "127.0.0.1"
+	} else {
+		return addr
+	}
+}

--- a/util/generate.go
+++ b/util/generate.go
@@ -1,0 +1,46 @@
+package util
+
+import (
+	uuid "github.com/satori/go.uuid"
+	"unsafe"
+)
+
+// GenerateUUID 生成一个UUID，长度为36
+func GenerateUUID() string {
+	return uuid.Must(uuid.NewV4(), nil).String()
+}
+
+// GenerateHash 将任意结构进行哈希，使用SDBM算法作为实现
+func GenerateHash[Key any](key Key) (hash uint) {
+	entityPtr := &key
+	hash = uint(0)
+	start := uintptr(unsafe.Pointer(entityPtr))
+	end := unsafe.Sizeof(key) + start
+	offset := unsafe.Sizeof(byte(0))
+
+	for i := start; i < end; i += offset {
+		b := *(*byte)(unsafe.Pointer(i))
+		hash = uint(b) + (hash << 6) + (hash << 16) - hash
+	}
+
+	return hash
+}
+
+// GeneratePrefixHash 将任意结构的前offset字节的内容进行哈希，越界部份不会被计算，使用SDBM算法作为实现
+func GeneratePrefixHash[Key any](key Key, offset uintptr) (hash uint) {
+	entityPtr := &key
+	hash = uint(0)
+	start := uintptr(unsafe.Pointer(entityPtr))
+	end := start + offset
+	if end > unsafe.Sizeof(key)+start {
+		end = unsafe.Sizeof(key) + start
+	}
+
+	byteOffset := unsafe.Sizeof(byte(0))
+	for i := start; i < end; i += byteOffset {
+		b := *(*byte)(unsafe.Pointer(i))
+		hash = uint(b) + (hash << 6) + (hash << 16) - hash
+	}
+
+	return hash
+}


### PR DESCRIPTION
完成了 #8 中的持久化模块要求，开始实现 #7 中的HTTP服务，主要改变了下列内容：

1. 增加了Localization的持久化，现在完全完成了 #8 的内容
2. 修改了persistence.Serve的阻塞逻辑，现在可以即时接收exit信号了
3. 实现了QPS限制器与UUID标识
4. 使用 go-gin 开始设计 #7 中的HTTP服务器，增加了部份中间件

修复了 #16 中的设计缺陷，做出了下列修改：

1. 新增了召唤物、支援物、对局信息等结构
2. 增加了回合阶段的枚举
3. 修改了SyncMessage的结构

同时做出了一些优化，主要有下列内容：

1. 修改了backend模式、cli模式的入口函数
2. 修改了github-action和drone-ci的基准性能测试配置，将基准性能测试降到了1秒钟
3. 修改了.gitignore和.gitkeep文件，使持久化文件不会被git标记