### PR TITLE
Fix sqlite3 errors, update http services

### DIFF
--- a/persistence/db.go
+++ b/persistence/db.go
@@ -31,6 +31,7 @@ var (
 	SkillPersistence     = newFactoryPersistence[Skill]()
 
 	LocalizationPersistence = newMemoryCache[string, localization.LanguagePack]()
+	TokenPersistence        = newTimingMemoryCache[string, Token]()
 
 	CardDeckPersistence DatabasePersistence[uint, CardDeck]
 	PlayerPersistence   DatabasePersistence[uint, Player]
@@ -64,9 +65,6 @@ func Load(errChan chan error) {
 			errChan <- err
 		} else {
 			sqlite3DB.SetMapper(core.SameMapper{})
-			if err = sqlite3DB.Sync2(Player{}, CardDeck{}); err != nil {
-				errChan <- err
-			}
 
 			var success bool
 			if success, CardDeckPersistence = newDatabasePersistence[uint, CardDeck](errChan); !success {

--- a/persistence/model.go
+++ b/persistence/model.go
@@ -31,7 +31,7 @@ type Character struct {
 	Skills      []uint
 }
 
-// Player 被持久化模块托管的PlayerInfo工厂
+// Player 被持久化模块托管的Player信息
 type Player struct {
 	UID       uint   `xorm:"pk autoincr notnull unique index"` // UID Player的UID，主键
 	NickName  string `xorm:"notnull varchar(64)"`              // NickName Player的昵称
@@ -39,11 +39,17 @@ type Player struct {
 	Password  string `xorm:"notnull varchar(64)"`              // Password Player的密码Hash
 }
 
-// CardDeck 被持久化模块托管的CardDeck工厂
+// CardDeck 被持久化模块托管的CardDeck信息
 type CardDeck struct {
 	ID               uint     `xorm:"pk autoincr notnull unique index"` // ID CardDeck的记录ID，主键
 	OwnerUID         uint     `xorm:"notnull index"`                    // OwnerUID CardDeck的持有者
 	RequiredPackages []string `xorm:"notnull json"`                     // RequiredPackages CardDeck需要的包
 	Cards            []uint   `xorm:"notnull json"`                     // Cards CardDeck包含的卡组
 	Characters       []uint   `xorm:"notnull json"`                     // Characters CardDeck包含的角色
+}
+
+// Token 被持久化模块托管的Token缓存
+type Token struct {
+	UID uint
+	ID  string
 }

--- a/protocol/http/config.go
+++ b/protocol/http/config.go
@@ -11,6 +11,11 @@ var (
 			InterdictorBlockedTime:  600,
 			InterdictorTriggerCount: 5,
 			QPSLimitTime:            1,
+			TokenIDKey:              "gisb_token_id",
+			TokenKey:                "gisb_token",
+			TokenRefreshTime:        7200,
+			TokenRemainingTime:      1800,
+			CookieDomain:            "localhost",
 		},
 		Backend: BackendConfig{
 			ListenPort: 8086,

--- a/protocol/http/middleware/authenticator.go
+++ b/protocol/http/middleware/authenticator.go
@@ -1,0 +1,54 @@
+package middleware
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/sunist-c/genius-invokation-simulator-backend/persistence"
+	"github.com/sunist-c/genius-invokation-simulator-backend/util"
+	"strconv"
+	"time"
+)
+
+// AttachToken 将Token信息附加给响应
+func AttachToken(ctx *gin.Context, conf Config, player uint) (success bool) {
+	uuid := GetUUID(ctx, conf)
+	ok, ip := GetIPTrace(ctx, conf)
+	if !ok {
+		return false
+	}
+	tokenID, token := util.GenerateMD5(strconv.Itoa(int(ip))), util.GenerateMD5(uuid)
+	if success, _ = persistence.TokenPersistence.InsertOne(token, persistence.Token{UID: player, ID: tokenID}, time.Second*time.Duration(conf.TokenRefreshTime)); !success {
+		return false
+	} else {
+		ctx.SetCookie(conf.TokenIDKey, tokenID, int(conf.TokenRefreshTime), "/", conf.CookieDomain, false, true)
+		ctx.SetCookie(conf.TokenKey, token, int(conf.TokenRefreshTime), "/", conf.CookieDomain, false, true)
+		return true
+	}
+}
+
+// GetToken 获取Cookie里的Token信息
+func GetToken(ctx *gin.Context, conf Config) (success bool, token persistence.Token) {
+	if result, err := ctx.Cookie(conf.TokenKey); err != nil {
+		return false, token
+	} else if has, tokenStruct, _ := persistence.TokenPersistence.QueryByID(result); !has {
+		return false, token
+	} else {
+		return true, tokenStruct
+	}
+}
+
+// NewAuthenticator 新建一个认证器，只有Cookie中的Token和ID正确时才会放行，但是没有具体处理是否有权限
+func NewAuthenticator(conf Config) func(ctx *gin.Context) {
+	return func(ctx *gin.Context) {
+		if tokenID, err := ctx.Cookie(conf.TokenIDKey); err != nil {
+			ctx.AbortWithStatus(403)
+		} else if token, err := ctx.Cookie(conf.TokenKey); err != nil {
+			ctx.AbortWithStatus(403)
+		} else if has, result, timeoutAt := persistence.TokenPersistence.QueryByID(token); !has {
+			ctx.AbortWithStatus(403)
+		} else if result.ID != tokenID {
+			ctx.AbortWithStatus(403)
+		} else if time.Now().Add(time.Duration(conf.TokenRemainingTime) * time.Second).After(timeoutAt) {
+			persistence.TokenPersistence.RefreshByID(token, time.Second*time.Duration(conf.TokenRefreshTime))
+		}
+	}
+}

--- a/protocol/http/middleware/config.go
+++ b/protocol/http/middleware/config.go
@@ -7,4 +7,9 @@ type Config struct {
 	InterdictorBlockedTime  uint   `json:"interdictor_blocked_time"`
 	InterdictorTriggerCount uint   `json:"interdictor_trigger_count"`
 	QPSLimitTime            uint   `json:"qps_limit_time"`
+	TokenIDKey              string `json:"token_id_key"`
+	TokenKey                string `json:"token_key"`
+	TokenRefreshTime        uint   `json:"token_refresh_time"`
+	TokenRemainingTime      uint   `json:"token_remaining_time"`
+	CookieDomain            string `json:"cookie_domain"`
 }

--- a/protocol/http/service/carddeck.go
+++ b/protocol/http/service/carddeck.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/sunist-c/genius-invokation-simulator-backend/persistence"
 	"github.com/sunist-c/genius-invokation-simulator-backend/protocol/http"
 	"github.com/sunist-c/genius-invokation-simulator-backend/protocol/http/middleware"
+	"github.com/sunist-c/genius-invokation-simulator-backend/protocol/http/util"
 )
 
 var (
@@ -17,11 +19,21 @@ func initCardDeckService() {
 		append(
 			http.EngineMiddlewares,
 			middleware.NewQPSLimiter(cfg),
+			middleware.NewAuthenticator(cfg),
 		)...,
 	)
 
 	deckRouter.POST("",
-		middleware.NewQPSLimiter(cfg),
+		uploadDeckServiceHandler(),
+	)
+	deckRouter.GET(":card_deck_id",
+		queryDeckServiceHandler(),
+	)
+	deckRouter.PUT(":card_deck_id",
+		updateDeckServiceHandler(),
+	)
+	deckRouter.DELETE(":card_deck_id",
+		deleteDeckServiceHandler(),
 	)
 }
 
@@ -40,26 +52,143 @@ type UploadCardDeckResponse struct {
 	Characters      []uint   `json:"characters"`
 }
 
+type UpdateCardDeckRequest struct {
+	Owner           uint     `json:"owner"`
+	RequiredPackage []string `json:"required_package"`
+	Cards           []uint   `json:"cards"`
+	Characters      []uint   `json:"characters"`
+}
+
+type UpdateCardDeckResponse struct {
+	ID              uint     `json:"id"`
+	Owner           uint     `json:"owner"`
+	RequiredPackage []string `json:"required_package"`
+	Cards           []uint   `json:"cards"`
+	Characters      []uint   `json:"characters"`
+}
+
+type QueryCardDeckResponse struct {
+	ID              uint     `json:"id"`
+	Owner           uint     `json:"owner"`
+	RequiredPackage []string `json:"required_package"`
+	Cards           []uint   `json:"cards"`
+	Characters      []uint   `json:"characters"`
+}
+
 func uploadDeckServiceHandler() func(ctx *gin.Context) {
 	return func(ctx *gin.Context) {
-
+		request := UploadCardDeckRequest{}
+		if !util.BindJson(ctx, &request) {
+			// RequestBody解析失败，BadRequest
+			ctx.AbortWithStatus(400)
+		} else if exist, tokenValue := middleware.GetToken(ctx, cfg); !exist {
+			// 服务器找不到token，Forbidden
+			ctx.AbortWithStatus(403)
+		} else if tokenValue.UID != request.Owner {
+			// 上传者和拥有者不同，Forbidden
+			ctx.AbortWithStatus(403)
+		} else if success, entity := persistence.CardDeckPersistence.InsertOne(&persistence.CardDeck{
+			OwnerUID:         request.Owner,
+			RequiredPackages: request.RequiredPackage,
+			Cards:            request.Cards,
+			Characters:       request.Characters,
+		}); !success {
+			// 插入失败，InternalError
+			ctx.AbortWithStatus(500)
+		} else {
+			// 插入成功，Success
+			ctx.JSON(200, UploadCardDeckResponse{
+				ID:              entity.ID,
+				Owner:           entity.OwnerUID,
+				RequiredPackage: entity.RequiredPackages,
+				Cards:           entity.Cards,
+				Characters:      entity.Characters,
+			})
+		}
 	}
 }
 
 func deleteDeckServiceHandler() func(ctx *gin.Context) {
 	return func(ctx *gin.Context) {
-
+		if gotten, id := util.QueryPathInt(ctx, ":card_deck_id"); !gotten {
+			// 找不到必要的URL路径参数，BadRequest
+			ctx.AbortWithStatus(400)
+		} else if exist, tokenValue := middleware.GetToken(ctx, cfg); !exist {
+			// 服务器找不到token，Forbidden
+			ctx.AbortWithStatus(403)
+		} else if has, entity := persistence.CardDeckPersistence.QueryByID(uint(id)); !has {
+			// 没找到要删除的卡组，NotFound
+			ctx.AbortWithStatus(404)
+		} else if tokenValue.UID != entity.OwnerUID {
+			// 删除者和拥有者不同，Forbidden
+			ctx.AbortWithStatus(403)
+		} else if success := persistence.CardDeckPersistence.DeleteOne(uint(id)); !success {
+			// 删除失败，InternalError
+			ctx.AbortWithStatus(500)
+		} else {
+			// 删除成功，Success
+			ctx.Status(200)
+		}
 	}
 }
 
 func updateDeckServiceHandler() func(ctx *gin.Context) {
 	return func(ctx *gin.Context) {
-
+		request := UpdateCardDeckRequest{}
+		if !util.BindJson(ctx, &request) {
+			// RequestBody解析失败，BadRequest
+			ctx.AbortWithStatus(400)
+		} else if gotten, id := util.QueryPathInt(ctx, ":card_deck_id"); !gotten {
+			// 找不到必要的URL路径参数，BadRequest
+			ctx.AbortWithStatus(400)
+		} else if exist, tokenValue := middleware.GetToken(ctx, cfg); !exist {
+			// 服务器里找不到token，Forbidden
+			ctx.AbortWithStatus(403)
+		} else if tokenValue.UID != request.Owner {
+			// 拥有者和更新者不一致，Forbidden
+			ctx.AbortWithStatus(403)
+		} else if has, _ := persistence.CardDeckPersistence.QueryByID(uint(id)); !has {
+			// 没找到要更新的卡组，NotFound
+			ctx.AbortWithStatus(404)
+		} else if success := persistence.CardDeckPersistence.UpdateByID(uint(id), persistence.CardDeck{
+			ID:               uint(id),
+			OwnerUID:         request.Owner,
+			RequiredPackages: request.RequiredPackage,
+			Cards:            request.Cards,
+			Characters:       request.Characters,
+		}); !success {
+			// 更新失败，InternalError
+			ctx.AbortWithStatus(500)
+		} else {
+			// 更新成功，Success
+			ctx.JSON(200, UpdateCardDeckResponse{
+				ID:              uint(id),
+				Owner:           request.Owner,
+				RequiredPackage: request.RequiredPackage,
+				Cards:           request.Cards,
+				Characters:      request.Characters,
+			})
+		}
 	}
 }
 
 func queryDeckServiceHandler() func(ctx *gin.Context) {
 	return func(ctx *gin.Context) {
-
+		if gotten, id := util.QueryPathInt(ctx, ":card_deck_id"); !gotten {
+			// 找不到必要的URL路径参数，BadRequest
+			ctx.AbortWithStatus(400)
+		} else if has, entity := persistence.CardDeckPersistence.QueryByID(uint(id)); !has {
+			// 找不到卡组，NotFound
+			ctx.AbortWithStatus(404)
+		} else if has {
+			// 找到了卡组，Success
+			ctx.JSON(200, QueryCardDeckResponse{
+				ID:              entity.ID,
+				Owner:           entity.OwnerUID,
+				RequiredPackage: entity.RequiredPackages,
+				Cards:           entity.Cards,
+				Characters:      entity.Characters,
+			})
+		}
 	}
 }

--- a/protocol/http/service/player.go
+++ b/protocol/http/service/player.go
@@ -30,11 +30,11 @@ func initPlayerService() {
 	playerRouter.POST("",
 		registerServiceHandler(),
 	)
-	playerRouter.PUT(":player_id/password",
+	playerRouter.PATCH(":player_id/password",
 		middleware.NewInterdictor(cfg),
 		updatePasswordServiceHandler(),
 	)
-	playerRouter.PUT(":player_id/nickname",
+	playerRouter.PATCH(":player_id/nickname",
 		middleware.NewInterdictor(cfg),
 		updateNickNameServiceHandler(),
 	)
@@ -103,6 +103,9 @@ func loginServiceHandler() func(ctx *gin.Context) {
 			// 密码校验失败，Forbidden，登陆失败
 			middleware.Interdict(ctx, cfg)
 			ctx.JSON(403, LoginResponse{Success: false})
+		} else if !middleware.AttachToken(ctx, cfg, uint(id)) {
+			// 生成token失败，InternalError
+			ctx.JSON(500, LoginResponse{Success: false})
 		} else {
 			// 登录成功，获取玩家卡组信息后返回登录成功响应
 			response := LoginResponse{


### PR DESCRIPTION
继续完成 #7 中的服务与设计，改变了：

1. 增加认证器中间件，通过Cookie-Token的方式实现认证，拒绝未认证通过的请求
2. 增加CardDeck服务，包括卡组的新增、更新、删除、查询接口，暂未与Player表进行联动
3. 修改Player服务中的更新密码和更新信息接口，改为PATCH方法
4. 修改Player服务中的登录接口，增加了认证器，登陆成功后自动增加授权Cookie

完全修复了 #19 中存在的逻辑错误，原因是未完全利用xorm的Get接口给出的has结果，导致不存在结果时也返回success