### PR TITLE
Basically complete the encapsulation of websocket.Connection

### DIFF
--- a/entity/core.go
+++ b/entity/core.go
@@ -194,8 +194,13 @@ func (c *Core) ExecuteAttack(sender uint, target uint, skill uint) {
 
 			// 如果此次攻击导致对方角色被击败，阻塞执行过程并等待对方切换角色
 			if _, activeCharacter := targetPlayer.GetActiveCharacter(); activeCharacter.Status() == enum.CharacterStatusDefeated {
+				targetPlayer.SetStatus(enum.PlayerStatusCharacterDefeated)
+				backup := senderPlayer.Status()
+				senderPlayer.SetStatus(enum.PlayerStatusWaiting)
 				c.defeatedChan <- SyncDefeatedCharacterMessage{WaitingPlayerUID: target}
 				<-c.waitChan
+				targetPlayer.SetStatus(enum.PlayerStatusWaiting)
+				senderPlayer.SetStatus(backup)
 			}
 
 			// 执行回调流程

--- a/entity/player.go
+++ b/entity/player.go
@@ -53,6 +53,7 @@ type Player interface {
 	PreviewElementCost(basic Cost) (result Cost)
 
 	ResetOperated()
+	SetStatus(status enum.PlayerStatus)
 	SetHoldingCost(cost Cost)
 
 	GetActiveCharacter() (has bool, character Character)
@@ -443,6 +444,10 @@ func (p *player) ExecuteConcede() {
 func (p *player) ResetOperated() {
 	p.status = enum.PlayerStatusActing
 	p.operated = false
+}
+
+func (p *player) SetStatus(status enum.PlayerStatus) {
+	p.status = status
 }
 
 func (p *player) ExecuteSummonSkills() {}

--- a/enum/player.go
+++ b/enum/player.go
@@ -4,10 +4,11 @@ package enum
 type PlayerStatus byte
 
 const (
-	PlayerStatusInitialized PlayerStatus = iota // PlayerStatusInitialized 玩家初始化完成
-	PlayerStatusReady                           // PlayerStatusReady 玩家在回合开始阶段准备
-	PlayerStatusWaiting                         // PlayerStatusWaiting 玩家在等待其他玩家操作
-	PlayerStatusActing                          // PlayerStatusActing 玩家正在执行操作
-	PlayerStatusDefeated                        // PlayerStatusDefeated 玩家被击败
-	PlayerStatusViewing                         // PlayerStatusViewing 玩家正在观战
+	PlayerStatusInitialized       PlayerStatus = iota // PlayerStatusInitialized 玩家初始化完成
+	PlayerStatusReady                                 // PlayerStatusReady 玩家在回合开始阶段准备
+	PlayerStatusWaiting                               // PlayerStatusWaiting 玩家在等待其他玩家操作
+	PlayerStatusActing                                // PlayerStatusActing 玩家正在执行操作
+	PlayerStatusDefeated                              // PlayerStatusDefeated 玩家被击败
+	PlayerStatusViewing                               // PlayerStatusViewing 玩家正在观战
+	PlayerStatusCharacterDefeated                     // PlayerStatusCharacterDefeated 玩家前台角色被击败，正在切换角色
 )

--- a/enum/trigger.go
+++ b/enum/trigger.go
@@ -4,7 +4,8 @@ package enum
 type TriggerType byte
 
 const (
-	AfterAttack     TriggerType = iota // AfterAttack 攻击结算后触发
+	AfterNone       TriggerType = iota // AfterNone 不会被触发的触发器
+	AfterAttack                        // AfterAttack 攻击结算后触发
 	AfterBurnCard                      // AfterBurnCard 使用卡牌转换元素后触发
 	AfterCharge                        // AfterCharge 充能后触发
 	AfterDefence                       // AfterDefence 防御结算后触发

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-playground/validator/v10 v10.11.1 // indirect
 	github.com/go-xorm/xorm v0.7.9 // indirect
 	github.com/goccy/go-json v0.10.0 // indirect
+	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect

--- a/mod/adapter/event.go
+++ b/mod/adapter/event.go
@@ -1,0 +1,1 @@
+package adapter

--- a/mod/adapter/mod.go
+++ b/mod/adapter/mod.go
@@ -1,0 +1,1 @@
+package adapter

--- a/mod/adapter/player.go
+++ b/mod/adapter/player.go
@@ -1,0 +1,1 @@
+package adapter

--- a/mod/adapter/skill.go
+++ b/mod/adapter/skill.go
@@ -1,0 +1,1 @@
+package adapter

--- a/mod/adapter/summon.go
+++ b/mod/adapter/summon.go
@@ -1,0 +1,1 @@
+package adapter

--- a/mod/definition/event.go
+++ b/mod/definition/event.go
@@ -1,0 +1,1 @@
+package adapter

--- a/mod/definition/mod.go
+++ b/mod/definition/mod.go
@@ -1,0 +1,1 @@
+package adapter

--- a/mod/definition/player.go
+++ b/mod/definition/player.go
@@ -1,0 +1,1 @@
+package adapter

--- a/mod/definition/skill.go
+++ b/mod/definition/skill.go
@@ -1,0 +1,1 @@
+package adapter

--- a/mod/definition/summon.go
+++ b/mod/definition/summon.go
@@ -1,0 +1,1 @@
+package adapter

--- a/model/adapter/adapter.go
+++ b/model/adapter/adapter.go
@@ -1,0 +1,5 @@
+package adapter
+
+type Adapter[Origin any, Dest any] interface {
+	Convert(source *Origin) (success bool, result *Dest)
+}

--- a/persistence/timing.go
+++ b/persistence/timing.go
@@ -1,8 +1,13 @@
 package persistence
 
 import (
+	"math/rand"
 	"sync"
 	"time"
+)
+
+var (
+	random = rand.New(rand.NewSource(time.Now().UnixNano()))
 )
 
 type timingCacheRecord[T any] struct {
@@ -51,6 +56,10 @@ func (t *timingMemoryCache[PK, T]) proactivelyClean(index float64) {
 }
 
 func (t *timingMemoryCache[PK, T]) serve(proactivelyCleanTime time.Duration, proactivelyCleanIndex float64) {
+	// 起服务前先随机sleep一会，让一起初始化的多个组建主动清理时间错开
+	randomNum := random.Int63n(int64(proactivelyCleanTime))
+	time.Sleep(time.Duration(randomNum))
+
 	for {
 		select {
 		case <-t.exit:

--- a/protocol/http/model/carddeck.go
+++ b/protocol/http/model/carddeck.go
@@ -1,0 +1,39 @@
+package model
+
+type UploadCardDeckRequest struct {
+	Owner           uint     `json:"owner"`
+	RequiredPackage []string `json:"required_package"`
+	Cards           []uint   `json:"cards"`
+	Characters      []uint   `json:"characters"`
+}
+
+type UploadCardDeckResponse struct {
+	ID              uint     `json:"id"`
+	Owner           uint     `json:"owner"`
+	RequiredPackage []string `json:"required_package"`
+	Cards           []uint   `json:"cards"`
+	Characters      []uint   `json:"characters"`
+}
+
+type UpdateCardDeckRequest struct {
+	Owner           uint     `json:"owner"`
+	RequiredPackage []string `json:"required_package"`
+	Cards           []uint   `json:"cards"`
+	Characters      []uint   `json:"characters"`
+}
+
+type UpdateCardDeckResponse struct {
+	ID              uint     `json:"id"`
+	Owner           uint     `json:"owner"`
+	RequiredPackage []string `json:"required_package"`
+	Cards           []uint   `json:"cards"`
+	Characters      []uint   `json:"characters"`
+}
+
+type QueryCardDeckResponse struct {
+	ID              uint     `json:"id"`
+	Owner           uint     `json:"owner"`
+	RequiredPackage []string `json:"required_package"`
+	Cards           []uint   `json:"cards"`
+	Characters      []uint   `json:"characters"`
+}

--- a/protocol/http/model/localization.go
+++ b/protocol/http/model/localization.go
@@ -1,0 +1,15 @@
+package model
+
+import "github.com/sunist-c/genius-invokation-simulator-backend/model/localization"
+
+type LocalizationQueryResponse struct {
+	LanguagePack localization.MultipleLanguagePack `json:"language_pack"`
+}
+
+type TranslationRequest struct {
+	Words []string `json:"words"`
+}
+
+type TranslationResponse struct {
+	Translation map[string]string `json:"translation"`
+}

--- a/protocol/http/model/player.go
+++ b/protocol/http/model/player.go
@@ -1,0 +1,43 @@
+package model
+
+import "github.com/sunist-c/genius-invokation-simulator-backend/persistence"
+
+type LoginResponse struct {
+	PlayerUID       uint                   `json:"player_uid"`
+	Success         bool                   `json:"success"`
+	PlayerNickName  string                 `json:"player_nick_name"`
+	PlayerCardDecks []persistence.CardDeck `json:"player_card_decks"`
+}
+
+type LoginRequest struct {
+	Password string `json:"password"`
+}
+
+type RegisterRequest struct {
+	NickName string `json:"nick_name"`
+	Password string `json:"password"`
+}
+
+type RegisterResponse struct {
+	PlayerUID      uint   `json:"player_uid"`
+	PlayerNickName string `json:"player_nick_name"`
+}
+
+type UpdatePasswordRequest struct {
+	OriginalPassword string `json:"original_password"`
+	NewPassword      string `json:"new_password"`
+}
+
+type UpdateNickNameRequest struct {
+	Password    string `json:"password"`
+	NewNickName string `json:"new_nick_name"`
+}
+
+type DestroyPlayerRequest struct {
+	Password string `json:"password"`
+	Confirm  bool   `json:"confirm"`
+}
+
+type DestroyPlayerResponse struct {
+	Success bool `json:"success"`
+}

--- a/protocol/http/service/carddeck.go
+++ b/protocol/http/service/carddeck.go
@@ -5,6 +5,7 @@ import (
 	"github.com/sunist-c/genius-invokation-simulator-backend/persistence"
 	"github.com/sunist-c/genius-invokation-simulator-backend/protocol/http"
 	"github.com/sunist-c/genius-invokation-simulator-backend/protocol/http/middleware"
+	"github.com/sunist-c/genius-invokation-simulator-backend/protocol/http/model"
 	"github.com/sunist-c/genius-invokation-simulator-backend/protocol/http/util"
 )
 
@@ -37,47 +38,9 @@ func initCardDeckService() {
 	)
 }
 
-type UploadCardDeckRequest struct {
-	Owner           uint     `json:"owner"`
-	RequiredPackage []string `json:"required_package"`
-	Cards           []uint   `json:"cards"`
-	Characters      []uint   `json:"characters"`
-}
-
-type UploadCardDeckResponse struct {
-	ID              uint     `json:"id"`
-	Owner           uint     `json:"owner"`
-	RequiredPackage []string `json:"required_package"`
-	Cards           []uint   `json:"cards"`
-	Characters      []uint   `json:"characters"`
-}
-
-type UpdateCardDeckRequest struct {
-	Owner           uint     `json:"owner"`
-	RequiredPackage []string `json:"required_package"`
-	Cards           []uint   `json:"cards"`
-	Characters      []uint   `json:"characters"`
-}
-
-type UpdateCardDeckResponse struct {
-	ID              uint     `json:"id"`
-	Owner           uint     `json:"owner"`
-	RequiredPackage []string `json:"required_package"`
-	Cards           []uint   `json:"cards"`
-	Characters      []uint   `json:"characters"`
-}
-
-type QueryCardDeckResponse struct {
-	ID              uint     `json:"id"`
-	Owner           uint     `json:"owner"`
-	RequiredPackage []string `json:"required_package"`
-	Cards           []uint   `json:"cards"`
-	Characters      []uint   `json:"characters"`
-}
-
 func uploadDeckServiceHandler() func(ctx *gin.Context) {
 	return func(ctx *gin.Context) {
-		request := UploadCardDeckRequest{}
+		request := model.UploadCardDeckRequest{}
 		if !util.BindJson(ctx, &request) {
 			// RequestBody解析失败，BadRequest
 			ctx.AbortWithStatus(400)
@@ -107,7 +70,7 @@ func uploadDeckServiceHandler() func(ctx *gin.Context) {
 				ctx.AbortWithStatus(500)
 			} else {
 				// 更新成功，Success
-				ctx.JSON(200, UploadCardDeckResponse{
+				ctx.JSON(200, model.UploadCardDeckResponse{
 					ID:              cardDeck.ID,
 					Owner:           cardDeck.OwnerUID,
 					RequiredPackage: cardDeck.RequiredPackages,
@@ -171,7 +134,7 @@ func deleteDeckServiceHandler() func(ctx *gin.Context) {
 
 func updateDeckServiceHandler() func(ctx *gin.Context) {
 	return func(ctx *gin.Context) {
-		request := UpdateCardDeckRequest{}
+		request := model.UpdateCardDeckRequest{}
 		if !util.BindJson(ctx, &request) {
 			// RequestBody解析失败，BadRequest
 			ctx.AbortWithStatus(400)
@@ -198,7 +161,7 @@ func updateDeckServiceHandler() func(ctx *gin.Context) {
 			ctx.AbortWithStatus(500)
 		} else {
 			// 更新成功，Success
-			ctx.JSON(200, UpdateCardDeckResponse{
+			ctx.JSON(200, model.UpdateCardDeckResponse{
 				ID:              uint(id),
 				Owner:           request.Owner,
 				RequiredPackage: request.RequiredPackage,
@@ -219,7 +182,7 @@ func queryDeckServiceHandler() func(ctx *gin.Context) {
 			ctx.AbortWithStatus(404)
 		} else if has {
 			// 找到了卡组，Success
-			ctx.JSON(200, QueryCardDeckResponse{
+			ctx.JSON(200, model.QueryCardDeckResponse{
 				ID:              entity.ID,
 				Owner:           entity.OwnerUID,
 				RequiredPackage: entity.RequiredPackages,

--- a/protocol/http/service/localization.go
+++ b/protocol/http/service/localization.go
@@ -3,10 +3,10 @@ package service
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/sunist-c/genius-invokation-simulator-backend/enum"
-	"github.com/sunist-c/genius-invokation-simulator-backend/model/localization"
 	"github.com/sunist-c/genius-invokation-simulator-backend/persistence"
 	"github.com/sunist-c/genius-invokation-simulator-backend/protocol/http"
 	"github.com/sunist-c/genius-invokation-simulator-backend/protocol/http/middleware"
+	"github.com/sunist-c/genius-invokation-simulator-backend/protocol/http/model"
 	"github.com/sunist-c/genius-invokation-simulator-backend/protocol/http/util"
 )
 
@@ -33,18 +33,6 @@ func initLocalizeService() {
 	)
 }
 
-type LocalizationQueryResponse struct {
-	LanguagePack localization.MultipleLanguagePack `json:"language_pack"`
-}
-
-type TranslationRequest struct {
-	Words []string `json:"words"`
-}
-
-type TranslationResponse struct {
-	Translation map[string]string `json:"translation"`
-}
-
 func queryLanguagePackServiceHandler() func(ctx *gin.Context) {
 	return func(ctx *gin.Context) {
 		if exist, result := util.QueryPath(ctx, ":id"); !exist {
@@ -52,7 +40,7 @@ func queryLanguagePackServiceHandler() func(ctx *gin.Context) {
 		} else if has, record := persistence.LocalizationPersistence.QueryByID(result); !has {
 			ctx.AbortWithStatus(404)
 		} else {
-			response := LocalizationQueryResponse{LanguagePack: record.Pack()}
+			response := model.LocalizationQueryResponse{LanguagePack: record.Pack()}
 			ctx.JSON(200, response)
 		}
 	}
@@ -64,7 +52,7 @@ func translateServiceServiceHandler() func(ctx *gin.Context) {
 			exist        bool
 			languagePack string
 			destLanguage int
-			request      TranslationRequest
+			request      model.TranslationRequest
 		)
 		if exist, languagePack = util.QueryPath(ctx, "language_package"); !exist {
 			ctx.AbortWithStatus(400)
@@ -76,7 +64,7 @@ func translateServiceServiceHandler() func(ctx *gin.Context) {
 			if has, dictionary := persistence.LocalizationPersistence.QueryByID(languagePack); !has {
 				ctx.AbortWithStatus(404)
 			} else {
-				response := TranslationResponse{Translation: map[string]string{}}
+				response := model.TranslationResponse{Translation: map[string]string{}}
 				language := enum.Language(destLanguage)
 				for _, word := range request.Words {
 					if ok, result := dictionary.Translate(word, language); ok {

--- a/protocol/websocket/config/handler.go
+++ b/protocol/websocket/config/handler.go
@@ -1,0 +1,17 @@
+package config
+
+var (
+	websocketConfig *WebsocketConfig
+)
+
+type WebsocketConfig struct {
+	HandshakeTimeout uint `json:"handshake_timeout" yaml:"handshake_timeout" xml:"handshake_timeout"`
+}
+
+func SetConfig(conf WebsocketConfig) {
+	*websocketConfig = conf
+}
+
+func GetConfig() WebsocketConfig {
+	return *websocketConfig
+}

--- a/protocol/websocket/config/handler.go
+++ b/protocol/websocket/config/handler.go
@@ -1,11 +1,23 @@
 package config
 
 var (
-	websocketConfig *WebsocketConfig
+	websocketConfig = &WebsocketConfig{
+		HandshakeTimeout:          60,
+		AllowCrossOrigin:          true,
+		WebsocketWriterBufferSize: 4096,
+		WebsocketReaderBufferSize: 4096,
+		ServerMessageBufferSize:   128,
+		AllowOriginDomains:        []string{""},
+	}
 )
 
 type WebsocketConfig struct {
-	HandshakeTimeout uint `json:"handshake_timeout" yaml:"handshake_timeout" xml:"handshake_timeout"`
+	HandshakeTimeout          uint     `json:"handshake_timeout" yaml:"handshake_timeout" xml:"handshake_timeout"`
+	AllowCrossOrigin          bool     `json:"allow_cross_origin" yaml:"allow_cross_origin" xml:"allow_cross_origin"`
+	WebsocketWriterBufferSize uint     `json:"websocket_writer_buffer_size" yaml:"websocket_writer_buffer_size" xml:"websocket_writer_buffer_size"`
+	WebsocketReaderBufferSize uint     `json:"websocket_reader_buffer_size" yaml:"websocket_reader_buffer_size" xml:"websocket_reader_buffer_size"`
+	ServerMessageBufferSize   uint     `json:"server_message_buffer_size" yaml:"server_message_buffer_size" xml:"server_message_buffer_size"`
+	AllowOriginDomains        []string `json:"allow_origin_domains" yaml:"allow_origin_domains" xml:"allow_origin_domains"`
 }
 
 func SetConfig(conf WebsocketConfig) {

--- a/protocol/websocket/engine.go
+++ b/protocol/websocket/engine.go
@@ -1,0 +1,140 @@
+package websocket
+
+import (
+	"encoding/json"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	"github.com/sunist-c/genius-invokation-simulator-backend/protocol/websocket/config"
+	"net/http"
+	"time"
+)
+
+func checkOriginHandler() func(r *http.Request) bool {
+	conf := config.GetConfig()
+	if conf.AllowCrossOrigin {
+		return func(r *http.Request) bool {
+			return true
+		}
+	} else {
+		return func(r *http.Request) bool {
+			// todo: optimize check origin logic
+			origin := r.Header.Get("Origin")
+			for _, allow := range conf.AllowOriginDomains {
+				if origin == allow {
+					return true
+				}
+			}
+
+			return false
+		}
+	}
+}
+
+func newUpgrader() *websocket.Upgrader {
+	conf := config.GetConfig()
+	return &websocket.Upgrader{
+		HandshakeTimeout: time.Second * time.Duration(conf.HandshakeTimeout),
+		ReadBufferSize:   int(conf.WebsocketReaderBufferSize),
+		WriteBufferSize:  int(conf.WebsocketWriterBufferSize),
+		CheckOrigin:      checkOriginHandler(),
+	}
+}
+
+type Connection struct {
+	conn     *websocket.Conn
+	exitChan chan struct{}
+	errChan  chan error
+	iStream  chan []byte // iStream 输入管道
+	oStream  chan []byte // oStream 输出管道
+}
+
+func (c *Connection) readLoop() {
+	for {
+		select {
+		case <-c.exitChan:
+			// 向exitChan写入信息通知其他协程
+			c.exitChan <- struct{}{}
+			return
+		default:
+			if messageType, reader, err := c.conn.ReadMessage(); err != nil {
+				// 发生错误，关闭WebSocket连接
+				c.errChan <- err
+				c.Close()
+			} else if messageType == websocket.TextMessage {
+				// 传输格式为json，只监听TextMessage
+				c.iStream <- reader
+			}
+		}
+	}
+}
+
+func (c *Connection) writeLoop() {
+	for {
+		select {
+		case <-c.exitChan:
+			// 向exitChan写入信息通知其他协程
+			c.exitChan <- struct{}{}
+			return
+		case outMessage := <-c.oStream:
+			if err := c.conn.WriteMessage(websocket.TextMessage, outMessage); err != nil {
+				// 发生错误，关闭WebSocket连接
+				c.errChan <- err
+				c.Close()
+			}
+		}
+	}
+}
+
+// Serve 启动WebsocketConnection的服务协程
+func (c *Connection) Serve() {
+	go c.readLoop()
+	go c.writeLoop()
+}
+
+func (c *Connection) Close() {
+	// 关闭客户端连接
+	if err := c.conn.Close(); err != nil {
+		c.errChan <- err
+	}
+
+	// 通知readLoop和writeLoop退出
+	c.exitChan <- struct{}{}
+
+	// 释放WebSocketConnection
+	c.conn = nil
+	close(c.iStream)
+	close(c.oStream)
+	close(c.exitChan)
+}
+
+func (c *Connection) Write(object interface{}) {
+	if jsonBytes, err := json.Marshal(object); err != nil {
+		c.errChan <- err
+	} else {
+		c.oStream <- jsonBytes
+	}
+}
+
+func (c *Connection) Read() <-chan []byte {
+	return c.iStream
+}
+
+func NewConnection(conn *websocket.Conn, errChan chan error) *Connection {
+	conf := config.GetConfig()
+	return &Connection{
+		conn:     conn,
+		iStream:  make(chan []byte, conf.ServerMessageBufferSize),
+		oStream:  make(chan []byte, conf.ServerMessageBufferSize),
+		exitChan: make(chan struct{}, 2),
+		errChan:  errChan,
+	}
+}
+
+// Upgrade 将HTTP连接升级为Websocket连接
+func Upgrade(ctx *gin.Context, errChan chan error) (success bool, connection *Connection) {
+	if conn, err := newUpgrader().Upgrade(ctx.Writer, ctx.Request, ctx.Request.Header); err != nil {
+		return false, nil
+	} else {
+		return true, NewConnection(conn, errChan)
+	}
+}

--- a/protocol/websocket/service/battle.go
+++ b/protocol/websocket/service/battle.go
@@ -1,0 +1,1 @@
+package service

--- a/protocol/websocket/service/match.go
+++ b/protocol/websocket/service/match.go
@@ -1,0 +1,1 @@
+package service


### PR DESCRIPTION
初步完成了 #10 中的websocket接口设计，主要做出了以下修改：

1. 使用 gorilla-websocket 作为 websocket实现
2. 完成了 websocket.Connectio 的封装，完成了其连接、释放、读、写的生命周期实现
3. 增加了 websocket.Config 以通过注入配置的方式控制 websocket 的实现

更新了 #7 中的部份服务，将各http服务的请求结构体和响应结构体移动到了 http.model 包中，以避免循环引用

更改了 #5 中的部份实现，更新了攻击结算逻辑，现在在攻击目标的前台角色被击败时，将阻塞正在执行的攻击逻辑，等待目标玩家切换前台角色后继续执行

更新了 #20 中的 TimingMemoryCache，增加了主动淘汰过期缓存的机制，同时使相同配置且同时初始化的 TimingMemoryCache 可以自动错峰进行淘汰

新建了两个文件夹：

1. mod 包
2. model.adapter 包
